### PR TITLE
chore: add contributor-friendly GitHub polish

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,43 @@
+name: Bug report
+description: Report something broken or unexpected
+title: "bug: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Please include enough detail to reproduce it.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Describe the bug and what you expected instead.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Run ...
+        2. See ...
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      placeholder: |
+        OS:
+        Python:
+        uv:
+        Agent host / CLI:
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or output
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,44 @@
+name: Feature request
+description: Suggest an idea or improvement
+title: "feat: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement. Early design feedback is especially welcome.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem would this solve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: What would you like Atelier to do?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - MCP / host integrations
+        - ReasonBlocks / reasoning reuse
+        - Failure rescue
+        - Evals / benchmarks
+        - Storage / retrieval
+        - CLI / SDK
+        - Docs / examples
+        - Other
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## Summary
+
+What changed?
+
+## Why
+
+Why is this useful?
+
+## Testing
+
+- [ ] `make lint`
+- [ ] `make format-check`
+- [ ] `make typecheck`
+- [ ] `make test`
+
+## Notes for reviewers
+
+Anything risky, uncertain, or worth extra attention?

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Lint
+        run: make lint
+
+      - name: Format check
+        run: make format-check
+
+      - name: Type check
+        run: make typecheck
+
+      - name: Test
+        run: make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         run: make lint
 
       - name: Format check
-        run: make format-check
+        run: uv run black --check src tests
 
       - name: Type check
         run: make typecheck

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,24 @@
+# Code of Conduct
+
+Atelier should be a welcoming project for people learning, experimenting, and contributing in public.
+
+## Expected behavior
+
+- Be kind and constructive.
+- Assume good intent, especially with new contributors.
+- Criticize ideas and code, not people.
+- Keep discussions focused on improving the project.
+- Make space for different experience levels and communication styles.
+
+## Unacceptable behavior
+
+- Harassment, insults, or personal attacks.
+- Discriminatory language or behavior.
+- Trolling, sustained disruption, or bad-faith participation.
+- Publishing private information without permission.
+
+## Reporting
+
+If something feels off, please contact the maintainer privately or open a GitHub issue if it is safe to do so.
+
+Maintainers may remove comments, close threads, or block participants when needed to keep the project healthy.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# Contributing
+
+Thanks for helping with Atelier.
+
+Start here: [docs/engineering/contributing.md](docs/engineering/contributing.md)
+
+## Good first contributions
+
+- Improve docs and examples
+- Add small tests for existing behavior
+- Reproduce and minimize bugs
+- Improve MCP/host installation notes
+- Add screenshots or demo GIFs
+
+Before opening a pull request, please run:
+
+```bash
+make pre-commit
+```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # Atelier — Open-Source Reasoning Runtime
 
+[![CI](https://github.com/pankaj4u4m/atelier/actions/workflows/ci.yml/badge.svg)](https://github.com/pankaj4u4m/atelier/actions/workflows/ci.yml)
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](LICENSE)
+[![Python](https://img.shields.io/badge/python-3.11%2B-blue)](pyproject.toml)
+[![Ruff](https://img.shields.io/badge/lint-ruff-blue)](https://github.com/astral-sh/ruff)
+[![Mypy](https://img.shields.io/badge/types-mypy-blue)](https://mypy-lang.org/)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
+
 An open-source reasoning runtime for coding agents and operational AI systems.
+
+> **Project status:** Atelier is early and experimental. The core shape is forming, but APIs, storage, integrations, and abstractions may change quickly. Contributors, design criticism, issues, and small PRs are very welcome.
 
 Atelier sits between agent hosts and their environments, providing:
 
@@ -22,6 +31,30 @@ Atelier sits between agent hosts and their environments, providing:
 - **Not an agent framework** — Atelier does not execute tools, manage model calls, or own the agent loop.
 - **Not an IDE** — Atelier runs as a sidecar to your agent host, not as a standalone coding environment.
 - **Not a vector database** — FTS5 is the default retrieval; pgvector is optional for semantic similarity.
+
+## Looking for contributors
+
+Good areas to help:
+
+- MCP integrations and host adapters
+- coding-agent workflows
+- Python backend/runtime work
+- memory and retrieval
+- evals, benchmarks, and reliability checks
+- docs, tutorials, examples, and demo GIFs
+- security review and hardening
+
+New contributors can start with issues labeled `good first issue` or `help wanted`.
+
+## Roadmap
+
+- [ ] Stable local runtime
+- [ ] MCP integration polish
+- [ ] Better ReasonBlock authoring flow
+- [ ] Failure rescue examples
+- [ ] Benchmarks and evals
+- [ ] Hosted/service mode hardening
+- [ ] Demo projects and screenshots
 
 ## Architecture
 
@@ -300,12 +333,12 @@ uv run atelier --root /tmp/bench savings-detail
 ### Per-model summary (5 tasks × 5 rounds = 25 calls each)
 
 | Model             | Would-have |   Actual |    Saved | % down |
-| ----------------- | ---------: | -------: | -------: | -----: | --- |
-| claude-opus-4.6   |   $ 4.3125 | $ 4.0088 | $ 0.3038 | 7.04 % |     |
-| claude-sonnet-4.6 |   $ 0.8625 | $ 0.8017 | $ 0.0607 | 7.04 % |     |
-| claude-haiku-4.5  |   $ 0.2300 | $ 0.2138 | $ 0.0162 | 7.04 % |     |
-| gpt-4o            |   $ 0.6250 | $ 0.5806 | $ 0.0444 | 7.10 % |     |
-| gemini-2.5-pro    |   $ 0.3125 | $ 0.2900 | $ 0.0225 | 7.18 % |     |
+| ----------------- | ---------: | -------: | -------: | -----: |
+| claude-opus-4.6   |   $ 4.3125 | $ 4.0088 | $ 0.3038 | 7.04 % |
+| claude-sonnet-4.6 |   $ 0.8625 | $ 0.8017 | $ 0.0607 | 7.04 % |
+| claude-haiku-4.5  |   $ 0.2300 | $ 0.2138 | $ 0.0162 | 7.04 % |
+| gpt-4o            |   $ 0.6250 | $ 0.5806 | $ 0.0444 | 7.10 % |
+| gemini-2.5-pro    |   $ 0.3125 | $ 0.2900 | $ 0.0225 | 7.18 % |
 
 The 7% is per-call savings from a single retrieved procedure plus prompt caching.
 On real workloads (many lessons per task, larger procedures) it scales toward the prompt-cache ceiling.
@@ -316,14 +349,13 @@ Full report: [docs/benchmarks/phase7-2026-04-29.md](docs/benchmarks/phase7-2026-
 
 ```bash
 cd atelier
-make install         # uv sync --all-extras
+make install         # deps + host integrations + status helper + runtime init
 make test            # pytest
 make lint            # ruff check
+make format-check    # black --check
 make typecheck       # mypy --strict
-make verify          # lint + typecheck + tests (CI gate)
+make verify          # code checks + runtime smoke tests + host verification
 make pre-commit      # format + lint + typecheck + tests
-make install-agent-clis  # install into all available agent CLIs
-make verify-agent-clis   # verify all integrations
 ```
 
 → Dev guide: [docs/engineering/contributing.md](docs/engineering/contributing.md)
@@ -349,3 +381,7 @@ make verify-agent-clis   # verify all integrations
 | **[docs/quickstart.md](docs/quickstart.md)**     | New users     | 5-minute tutorial                                      |
 | **[docs/engineering/](docs/engineering/)**       | Contributors  | Architecture, security, storage, service, MCP          |
 | **[docs/hosts/](docs/hosts/)**                   | Integrators   | Per-host install, verify, uninstall, troubleshooting   |
+
+## License
+
+Apache-2.0. See [LICENSE](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# Security Policy
+
+Atelier is early and experimental, but security issues are still important.
+
+## Reporting a vulnerability
+
+Please do not open a public issue for sensitive security reports.
+
+Instead, email the maintainer at pankaj4u4m@gmail.com with:
+
+- A short description of the issue
+- Steps to reproduce, if possible
+- Impact and affected versions or commits, if known
+- Any suggested fix or mitigation
+
+## Scope
+
+Security-sensitive areas include:
+
+- Secret handling and redaction
+- MCP/server interfaces
+- Tool execution boundaries
+- File reading/searching behavior
+- HTTP service authentication
+- Generated config or installer scripts
+
+## Expectations
+
+This project is pre-1.0, so APIs and internals may change quickly. I will try to acknowledge credible reports and prioritize fixes based on severity and exploitability.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,12 @@ version = "0.1.0"
 description = "Beseam Reasoning Runtime — reusable procedures, failure rescue, and rubric verification for coding and product agents."
 readme = "README.md"
 requires-python = ">=3.11"
-license = { text = "Proprietary" }
+license = { text = "Apache-2.0" }
 authors = [{ name = "Beseam" }]
+
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+]
 
 dependencies = [
     "pydantic>=2.6",
@@ -19,7 +23,7 @@ dependencies = [
     "GitPython>=3.1",
     "prometheus-client>=0.21",
     "tenacity>=9.0",
-    "pybreaker>=1.2",
+    "pybreaker>=0.22",
     "river>=0.22",
     "networkx>=3.4",
     "mypy>=1.20.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "GitPython>=3.1",
     "prometheus-client>=0.21",
     "tenacity>=9.0",
-    "pybreaker>=0.22",
+    "pybreaker>=1.2",
     "river>=0.22",
     "networkx>=3.4",
     "mypy>=1.20.2",
@@ -98,7 +98,7 @@ testpaths = ["tests"]
 addopts = "-ra --strict-markers"
 pythonpath = ["src", "."]
 markers = [
-    "slow: marks tests as slow",
+    "slow: marks tests slow",
 ]
 
 [tool.mypy]


### PR DESCRIPTION
## Summary

This PR makes the repo more contributor-friendly and open-source ready.

Changes include:

- Add Apache-2.0 `LICENSE`
- Update package metadata from proprietary to Apache-2.0
- Add README badges, project status, contributor callout, roadmap, and license section
- Add GitHub Actions CI
- Add root `CONTRIBUTING.md`
- Add `CODE_OF_CONDUCT.md` and `SECURITY.md`
- Add issue templates and PR template
- Add Dependabot config

## Notes

I kept this as a PR for review rather than merging directly.

## Follow-up ideas

- Add repo topics in GitHub settings: `ai-agents`, `coding-agents`, `mcp`, `llm`, `developer-tools`, `python`, `agent-memory`, `evals`, `automation`, `reasoning`
- Enable GitHub Discussions
- Add a demo GIF or screenshot
- Add more starter issues