### PR TITLE
Add smoke test for CLI help output

### DIFF
--- a/tests/gateway/test_cli_help.py
+++ b/tests/gateway/test_cli_help.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from click.testing import CliRunner
+
+from atelier.gateway.adapters.cli import cli
+
+
+def test_cli_help_shows_core_commands() -> None:
+    result = CliRunner().invoke(cli, ["--help"])
+
+    assert result.exit_code == 0, result.output
+
+    output = result.output
+    assert "init" in output
+    assert "context-report" in output
+    assert "proof" in output
+    assert "search-read" in output


### PR DESCRIPTION
Closes #5

## Summary

Adds a smoke test for the top-level CLI help output.

The test verifies that `atelier --help` runs successfully and that representative core commands are listed in the help output.

## Test

```bash
uv run pytest tests/gateway/test_cli_help.py