### PR TITLE
Add star history chart to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,3 +296,13 @@ Benchmarks, engineering internals, and repo structure live below the user journe
 | `docs/`         | user, integration, and engineering documentation           |
 | `integrations/` | host adapter configs and install/verify scripts            |
 | `frontend/`     | optional React + Vite visualization stack                  |
+
+## Star History
+
+<a href="https://star-history.com/#atelier-runtime/atelier&Date">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=atelier-runtime/atelier&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=atelier-runtime/atelier&type=Date" />
+    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=atelier-runtime/atelier&type=Date" />
+  </picture>
+</a>


### PR DESCRIPTION
## Summary
- Add a Star History section at the bottom of the README
- Embed a light/dark-aware star count over time chart for atelier-runtime/atelier

## Testing
- Not run; documentation-only change