### PR TITLE
fix(mcp): resolve relative edit paths against the session worktree

### DIFF
--- a/src/lemoncrow/gateway/adapters/mcp_server.py
+++ b/src/lemoncrow/gateway/adapters/mcp_server.py
@@ -3513,6 +3513,75 @@ def _workspace_root() -> Path:
     return Path(workspace)
 
 
+_last_session_cwd: str | None = None
+"""Most recent explicit ``cwd`` seen on a ``bash`` call, or None.
+
+This server is a long-lived process whose own ``os.getcwd()`` is fixed at
+launch, and MCP carries no per-call session cwd (we implement no ``roots``
+capability). So when a session enters a git worktree, :func:`_workspace_root`
+keeps naming the *main checkout*. A bash call's explicit ``cwd`` is the only
+place the session's real working directory reaches this process, which is why
+bash honored the worktree and edit did not. Recorded here and used to resolve
+relative edit paths -- see :func:`_session_worktree_root`.
+
+lc-debt: process-global, so a shared HTTP-mode server hosting two sessions on
+the SAME repo could let one session's worktree cwd redirect the other's
+relative edits (a foreign repo is already rejected by the
+``<root>/.git/worktrees`` check, and the redirect is always disclosed).
+Upgrade path: key this by MCP session id once the dispatcher threads one
+through, or drop it entirely if the protocol ever carries a per-call cwd.
+"""
+
+
+def _record_session_cwd(name: str, args: Any) -> None:
+    """Remember a bash call's cwd, the only session-cwd signal this server gets."""
+    global _last_session_cwd
+    if name != "bash" or not isinstance(args, dict):
+        return
+    cwd = args.get("cwd")
+    if isinstance(cwd, str) and cwd.strip():
+        _last_session_cwd = cwd.strip()
+
+
+def _session_worktree_root(workspace_root: Path) -> Path | None:
+    """The linked git worktree the session is working in, else None.
+
+    Detected without spawning git: a linked worktree's ``.git`` is a *file*
+    holding ``gitdir: <path>``, and for a worktree of THIS repo that path lives
+    under ``<workspace_root>/.git/worktrees/``. A normal checkout has ``.git``
+    as a directory, which ends the walk immediately.
+
+    Returns None for every uncertain case -- no recorded cwd, a plain
+    directory, a worktree belonging to a different repo -- so resolution falls
+    back to the workspace root exactly as before.
+    """
+    recorded = _last_session_cwd
+    if not recorded:
+        return None
+    try:
+        candidate = Path(recorded).expanduser().resolve()
+        if not candidate.is_dir():
+            return None
+        root = workspace_root.resolve()
+        worktrees_dir = (root / ".git" / "worktrees").resolve()
+        for directory in (candidate, *candidate.parents):
+            marker = directory / ".git"
+            if marker.is_dir():
+                return None  # a normal checkout, not a linked worktree
+            if not marker.is_file():
+                continue
+            gitdir = marker.read_text(encoding="utf-8").strip()
+            if not gitdir.startswith("gitdir:"):
+                return None
+            target = Path(gitdir.split(":", 1)[1].strip()).resolve()
+            if not target.is_relative_to(worktrees_dir):
+                return None  # a worktree, but of some other repo
+            return None if directory == root else directory
+    except OSError:
+        return None
+    return None
+
+
 # Thread-local slot for passing real tokens_saved from tool handlers to the
 # budget recorder without polluting the LLM-facing response dict.
 # _tool_call_tokens_saved moved to mcp.smart_state (imported/re-exported).
@@ -5229,7 +5298,10 @@ def render_tool_result_text(name: str, result: Any) -> str | None:
         # (the just-edited file always shows), so treating it like an
         # actionable key would blow the minimal render up on every call.
         keys = set(payload)
-        base_keys = keys - {"vcs_status"}
+        # `resolved_against` rides as a one-liner suffix like vcs_status rather
+        # than tripping the JSON fallback -- a redirected edit is still a clean
+        # success and should not render as a structured dump.
+        base_keys = keys - {"vcs_status", "resolved_against"}
         if base_keys <= {"calls_saved"}:
             text = "ok"
         elif base_keys <= {"applied", "calls_saved"}:
@@ -5239,6 +5311,9 @@ def render_tool_result_text(name: str, result: Any) -> str | None:
             elif not applied:
                 text = "ok"
         if text:
+            resolved_against = payload.get("resolved_against")
+            if isinstance(resolved_against, str) and resolved_against:
+                text = f"{text} | resolved against worktree {resolved_against} (from last bash cwd)"
             vcs_raw = payload.get("vcs_status")
             vcs = vcs_raw if isinstance(vcs_raw, dict) else {}
             vcs_lines = vcs.get("lines")
@@ -7288,6 +7363,11 @@ def _silence_clean_edit_result(result: dict[str, Any]) -> dict[str, Any]:
             silent["applied"] = applied
         if "calls_saved" in result:
             silent["calls_saved"] = result["calls_saved"]
+        # A redirected edit is never silent about being redirected: the whole
+        # point of the disclosure is that it survives the clean-success path,
+        # which is exactly where a wrong worktree inference would hide.
+        if "resolved_against" in result:
+            silent["resolved_against"] = result["resolved_against"]
         return silent
     for key in _EDIT_NOISE_KEYS:
         result.pop(key, None)
@@ -7420,15 +7500,33 @@ def tool_smart_edit(
     # workspace env + per-request project override) so write-confinement below
     # matches the active workspace.
     repo_root = _workspace_root()
+    # A session that entered a git worktree keeps calling this same long-lived
+    # server, whose _workspace_root() still names the MAIN CHECKOUT. A relative
+    # edit path therefore resolved to the wrong copy of the file -- and passed
+    # write-confinement unnoticed, because in-repo worktrees
+    # (<repo>/.claude/worktrees/...) sit *under* that root. Resolve relative
+    # paths against the worktree the session is demonstrably working in.
+    #
+    # This is an INFERENCE (from the last bash cwd), so it is never silent:
+    # `resolved_against` rides on the result, survives the clean-success
+    # squelch, and renders as a suffix on the one-liner. Absolute paths are
+    # unaffected -- _resolve_snapshot_path only applies a root to relative ones.
+    _session_worktree = _session_worktree_root(repo_root)
+    _edit_root = _session_worktree or repo_root
     edits = [_normalize_edit_aliases(e) for e in edits]
     _require_edits(edits)
 
-    paths = _collect_touched_paths(edits, repo_root=repo_root)
+    paths = _collect_touched_paths(edits, repo_root=_edit_root)
     # Confine writes to the workspace root plus any additional directories from
     # Claude Code's additionalDirectories setting or LEMONCROW_ADDITIONAL_DIRS env.
     # Read tools accept any absolute path; writes need explicit opt-in.
-    _extra_roots = [*_claude_additional_dirs(repo_root), Path("/tmp")]
-    _allowed_edit_roots = [repo_root, *_extra_roots]
+    # Path("/tmp").resolve() as well as "/tmp": on macOS /tmp is a symlink to
+    # /private/tmp, and the candidates below are resolved, so the bare literal
+    # never matched and the /tmp allowance was dead on that platform.
+    _extra_roots = [*_claude_additional_dirs(repo_root), Path("/tmp"), Path("/tmp").resolve()]
+    if _session_worktree is not None:
+        _extra_roots.append(_session_worktree)
+    _allowed_edit_roots = [repo_root, _edit_root, *_extra_roots]
 
     _escaped_edit_paths = [
         str(_p) for _p in paths.values() if not any(_p == _r or _p.is_relative_to(_r) for _r in _allowed_edit_roots)
@@ -7644,7 +7742,7 @@ def tool_smart_edit(
 
         from lemoncrow.pro.capabilities.tool_supervision.rich_edit import apply_rich_edits
 
-        result = apply_rich_edits(edits, atomic=atomic, repo_root=repo_root, allowed_roots=_extra_roots)
+        result = apply_rich_edits(edits, atomic=atomic, repo_root=_edit_root, allowed_roots=_extra_roots)
 
         # Sync the long-lived engine's index-version cache so the next explore
         # call gets a cache miss and re-queries the FTS5 index (which the
@@ -7849,6 +7947,10 @@ def tool_smart_edit(
         # Incremental: refresh the shared index for the touched files now, so a
         # follow-up search/explore reflects this edit without the autosync lag.
         _reindex_edited_files(repo_root, [str(p) for p in paths.values()])
+    # Disclose the worktree redirect. It is an inference, so a wrong one has to
+    # be visible in the same breath as the write it misdirected.
+    if _session_worktree is not None:
+        result["resolved_against"] = str(_session_worktree)
     return _silence_clean_edit_result(result)
 
 
@@ -11733,6 +11835,10 @@ def _handle(request: dict[str, Any]) -> dict[str, Any] | _Deferred | None:
         # N10 — request-scoped project isolation. Honor an Mcp-Project-Path-style
         # override for the lifetime of this request only; absent -> unchanged.
         _prior_project = _set_request_project(_extract_request_project(params, args if isinstance(args, dict) else {}))
+        # A bash cwd is the only place the session's real working directory
+        # reaches this long-lived process; record it so edit can resolve
+        # relative paths against a worktree the session has entered.
+        _record_session_cwd(name, args)
         _call_duration_ms: int = 0
         _call_started = time.perf_counter()
 

--- a/tests/gateway/test_edit_mcp_handler.py
+++ b/tests/gateway/test_edit_mcp_handler.py
@@ -1191,9 +1191,9 @@ def test_relocation_never_lands_on_different_content_under_random_drift() -> Non
         if got is None:  # fails closed -- always allowed
             continue
         relocated += 1
-        assert (
-            current_text.splitlines()[got[0] - 1 : got[1]] == served_text.splitlines()[start - 1 : end]
-        ), f"L{start}-L{end} -> L{got[0]}-L{got[1]} changed the content under the edit"
+        assert current_text.splitlines()[got[0] - 1 : got[1]] == served_text.splitlines()[start - 1 : end], (
+            f"L{start}-L{end} -> L{got[0]}-L{got[1]} changed the content under the edit"
+        )
     assert relocated > 1000, f"fuzz degenerated into all-rejections ({relocated} resolved)"
 
 
@@ -1291,3 +1291,120 @@ def test_tiny_fragment_without_old_still_rejected(workspace: Path) -> None:
     payload = _edit({"path": "frag.py", "new": "Y = 2\n", "hooks": False})
     assert "failed" in payload, payload
     assert f.read_text(encoding="utf-8") == original
+
+
+# ---------------------------------------------------------------------------
+# Worktree-aware relative path resolution
+#
+# The MCP server is long-lived and its own cwd is fixed at launch, so a session
+# that enters a git worktree used to have its RELATIVE edit paths silently
+# resolved against the main checkout -- writing the right change to the wrong
+# copy of the file, and passing write-confinement because in-repo worktrees sit
+# under the workspace root.
+# ---------------------------------------------------------------------------
+
+
+def _git(*args: str, cwd: Path) -> None:
+    import subprocess
+
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True)
+
+
+def _repo_with_worktree(root: Path) -> Path:
+    """Init a git repo at `root` and add a linked worktree; return the worktree."""
+    _git("init", "-q", cwd=root)
+    _git("config", "user.email", "t@example.com", cwd=root)
+    _git("config", "user.name", "t", cwd=root)
+    (root / "seed.txt").write_text("seed\n", encoding="utf-8")
+    _git("add", "-A", cwd=root)
+    _git("commit", "-qm", "seed", cwd=root)
+    wt = root / ".claude" / "worktrees" / "wt"
+    wt.parent.mkdir(parents=True, exist_ok=True)
+    _git("worktree", "add", "-q", str(wt), "-b", "wt-branch", cwd=root)
+    return wt
+
+
+def test_relative_edit_follows_the_session_into_a_worktree(workspace: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A relative path writes to the worktree the session is in, not the main checkout."""
+    wt = _repo_with_worktree(workspace)
+    (workspace / "target.txt").write_text("MAIN\n", encoding="utf-8")
+    (wt / "target.txt").write_text("WORKTREE\n", encoding="utf-8")
+    monkeypatch.setattr(mcp_server, "_last_session_cwd", str(wt))
+
+    payload = _edit(
+        {
+            "post_edit_hooks": False,
+            "edits": [{"file_path": "target.txt", "old_string": "WORKTREE", "new_string": "EDITED"}],
+        }
+    )
+
+    assert "failed" not in payload, payload
+    assert (wt / "target.txt").read_text(encoding="utf-8") == "EDITED\n"
+    # The whole point: the main checkout is untouched.
+    assert (workspace / "target.txt").read_text(encoding="utf-8") == "MAIN\n"
+
+
+def test_worktree_redirect_is_disclosed_to_the_model(workspace: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The redirect is inferred from the last bash cwd, so it is never silent.
+
+    A clean success is normally squelched to `applied path:line`; a wrong
+    inference would then be invisible exactly when it misdirected a write.
+    """
+    wt = _repo_with_worktree(workspace)
+    (wt / "target.txt").write_text("WORKTREE\n", encoding="utf-8")
+    monkeypatch.setattr(mcp_server, "_last_session_cwd", str(wt))
+
+    text = _edit_text(
+        {
+            "post_edit_hooks": False,
+            "edits": [{"file_path": "target.txt", "old_string": "WORKTREE", "new_string": "EDITED"}],
+        }
+    )
+
+    assert "resolved against worktree" in text, text
+    assert str(wt) in text, text
+
+
+def test_no_worktree_evidence_keeps_the_main_checkout(workspace: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without a worktree cwd, resolution is unchanged -- and says nothing."""
+    _repo_with_worktree(workspace)
+    (workspace / "target.txt").write_text("MAIN\n", encoding="utf-8")
+    monkeypatch.setattr(mcp_server, "_last_session_cwd", str(workspace))
+
+    text = _edit_text(
+        {
+            "post_edit_hooks": False,
+            "edits": [{"file_path": "target.txt", "old_string": "MAIN", "new_string": "EDITED"}],
+        }
+    )
+
+    assert (workspace / "target.txt").read_text(encoding="utf-8") == "EDITED\n"
+    assert "resolved against" not in text, text
+
+
+def test_a_worktree_of_another_repo_does_not_redirect(
+    workspace: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Only a worktree of THIS repo counts; a foreign one falls back to the root."""
+    _repo_with_worktree(workspace)
+    other = tmp_path.parent / "other-repo"
+    other.mkdir(parents=True, exist_ok=True)
+    foreign_wt = _repo_with_worktree(other)
+    monkeypatch.setattr(mcp_server, "_last_session_cwd", str(foreign_wt))
+
+    assert mcp_server._session_worktree_root(workspace) is None
+
+
+def test_bash_cwd_is_what_teaches_edit_where_the_session_is(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Only a bash call's cwd is recorded -- it is the sole session-cwd signal."""
+    monkeypatch.setattr(mcp_server, "_last_session_cwd", None)
+
+    mcp_server._record_session_cwd("read", {"cwd": "/not/recorded"})
+    assert mcp_server._last_session_cwd is None
+
+    mcp_server._record_session_cwd("bash", {"cwd": "/recorded"})
+    assert mcp_server._last_session_cwd == "/recorded"
+
+    # A bash call without an explicit cwd must not clear what we know.
+    mcp_server._record_session_cwd("bash", {})
+    assert mcp_server._last_session_cwd == "/recorded"


### PR DESCRIPTION
## The bug

When a session works inside a git worktree, `edit` resolves **relative** paths against the main checkout and writes the right change to the wrong copy of the file.

Reproduced against a worktree in the layout agent workflows commonly create (`<repo>/.claude/worktrees/<name>`), with the same relative path present in both copies:

```
before   main checkout : MAIN CHECKOUT
         worktree copy : WORKTREE

edit(path="probe_target.txt", replace=true)   ->  ok

after    main checkout : EDITED VIA RELATIVE PATH   <-- wrong file
         worktree copy : WORKTREE                   <-- untouched
```

Absolute paths are unaffected, so only relative paths are at risk.

## Why it happens, and why it is silent

`tool_smart_edit` resolves relative paths against `_workspace_root()`, which falls back to `os.getcwd()`. The MCP server is a **long-lived process whose cwd is fixed at launch**, and MCP carries no per-call session cwd (no `roots` capability), so entering a worktree never changes it.

What turns a wrong answer into a silent one: in-repo worktrees live *under* the workspace root, so the mis-resolved path still passes write-confinement. No error, no diagnostic — the call reports success against a file the caller never named. A blind retry then applies the same edit twice.

A `bash` call's explicit `cwd` is the only place the session's real working directory reaches this process. That is precisely why `bash` honors the worktree and `edit` does not.

## The fix

Record the `cwd` of `bash` calls in the dispatcher, and resolve relative edit paths against the linked worktree it names.

Detection spawns no git and costs a couple of `stat` calls: a linked worktree's `.git` is a *file* containing `gitdir: <path>`, and for a worktree of **this** repo that path lives under `<workspace_root>/.git/worktrees/`. A `.git` directory ends the walk immediately. Every uncertain case — no recorded cwd, a plain directory, a worktree belonging to another repo — returns `None`, and resolution is byte-for-byte what it was.

Because the redirect is an **inference**, it is never silent. `resolved_against` rides on the result, survives `_silence_clean_edit_result` (the clean-success squelch — exactly where a wrong inference would otherwise hide), and renders as a one-liner suffix rather than tripping the JSON fallback:

```
applied apps/api/x.ts:L10-L14 | resolved against worktree /repo/.claude/worktrees/iss-5071 (from last bash cwd)
```

`_collect_touched_paths` and `apply_rich_edits` are given the same root, so the snapshot/rollback set cannot drift from the write set.

### Also fixed

The `/tmp` write allowance was **inert on macOS**: candidates are `.resolve()`d to `/private/tmp`, but the allow-list held the bare `Path("/tmp")`, so `is_relative_to` never matched. Found while probing this bug; both forms are now allowed.

## Known limitation, marked in-code

The recorder is process-global. A shared HTTP-mode server hosting two sessions on the **same** repo could let one session's worktree cwd redirect the other's relative edits. A worktree of a different repo is already rejected, and the redirect is always disclosed. The comment names the upgrade path: key by MCP session id once the dispatcher threads one through, or delete this entirely if the protocol ever carries a per-call cwd.

Happy to take direction here if you would rather refuse ambiguous relative paths outright than redirect-and-disclose.

## Verification

The 5 new tests **fail on unpatched `main` and pass with the fix** — confirmed by reverting `mcp_server.py` and re-running, not assumed:

```
unpatched: 5 failed
patched:   5 passed
```

`tests/gateway/test_edit_mcp_handler.py` as a whole: **66 passed**.

`mypy --strict` on the changed file: **55 errors before, 55 after** — none in the added regions. `ruff check` clean, `ruff format --check` clean, `git diff --check` clean.

The tests build a real git repo and a real linked worktree rather than mocking the detection, so they exercise the actual `.git`-file parsing.

> Note on `make pre-commit`: it was not run in full here. This checkout has no `src/lemoncrow/pro` source (public mirror), so the project build and a portion of the suite cannot run locally; the scoped equivalents above were run instead, each against a same-command baseline on `main`.
