### PR TITLE
fix(mcp): bound the machine-global smart_state flock

### DIFF
--- a/src/lemoncrow/gateway/adapters/mcp/smart_state.py
+++ b/src/lemoncrow/gateway/adapters/mcp/smart_state.py
@@ -12,8 +12,10 @@ from __future__ import annotations
 import contextlib
 import json
 import logging
+import os
 import tempfile
 import threading
+import time
 from pathlib import Path
 from typing import Any
 
@@ -67,10 +69,38 @@ def _write_smart_state(state: dict[str, Any]) -> None:
         logger.warning("Suppressed exception while writing smart_state", exc_info=True)
 
 
+#: How long :func:`_acquire_smart_state_flock` waits for the machine-global lock
+#: before giving up. The lock file lives under the LemonCrow root, so it is held
+#: across every MCP process and daemon on the machine -- a blocking acquisition
+#: makes one stalled holder park every tool call everywhere. Read fresh per call
+#: so it can be tuned (or set to 0) without a restart.
+_DEFAULT_FLOCK_TIMEOUT_S = 5.0
+
+
+def _smart_state_flock_timeout() -> float:
+    raw = os.environ.get("LEMONCROW_SMART_STATE_LOCK_TIMEOUT", "").strip()
+    if not raw:
+        return _DEFAULT_FLOCK_TIMEOUT_S
+    try:
+        return max(0.0, float(raw))
+    except ValueError:
+        return _DEFAULT_FLOCK_TIMEOUT_S
+
+
 def _acquire_smart_state_flock() -> Any:
     """Best-effort POSIX exclusive flock on smart_state's sidecar lock file so a
     sibling MCP process can't lose-update the machine-global counters. Returns an
-    open handle the caller must release, or None where flock is unavailable."""
+    open handle the caller must release, or None where flock is unavailable or
+    the lock stayed busy past the timeout.
+
+    Bounded on purpose. A blocking ``LOCK_EX`` waits forever, and this lock is
+    machine-global: any process that stalls while holding it parks every tool
+    call in every other MCP process behind it, with no error and no deadline --
+    the call has already done its real work and is queued only to record a
+    counter. Giving up degrades to the same unsynchronised path non-POSIX
+    platforms already take: worst case a lost counter update, which is cheaper
+    than an unbounded stall.
+    """
     try:
         import fcntl
     except ImportError:
@@ -80,10 +110,23 @@ def _acquire_smart_state_flock() -> Any:
         lock_path = p.parent / (p.name + ".lock")
         lock_path.parent.mkdir(parents=True, exist_ok=True)
         handle = open(lock_path, "w", encoding="utf-8")
-        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
-        return handle
     except OSError:
         return None
+    deadline = time.monotonic() + _smart_state_flock_timeout()
+    delay = 0.005
+    while True:
+        try:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return handle
+        except OSError:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                logger.debug("smart_state flock busy past timeout; proceeding unsynchronised")
+                with contextlib.suppress(OSError):
+                    handle.close()
+                return None
+            time.sleep(min(delay, remaining))
+            delay = min(delay * 2, 0.1)
 
 
 def _release_smart_state_flock(handle: Any) -> None:

--- a/tests/gateway/test_mcp_tool_handlers.py
+++ b/tests/gateway/test_mcp_tool_handlers.py
@@ -2757,6 +2757,50 @@ def test_render_bash_text_includes_spill_hint_in_truncation_notice() -> None:
     assert "[output truncated: 50 lines omitted]" not in text
 
 
+def test_smart_state_flock_gives_up_instead_of_waiting_forever(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A busy machine-global lock must not park the caller indefinitely.
+
+    The lock file is shared by every MCP process on the machine, so a blocking
+    acquisition lets one stalled holder park every tool call everywhere -- after
+    the call has already done its real work and is queued only to record a
+    counter.
+    """
+    import fcntl
+    import time as _time
+
+    from lemoncrow.gateway.adapters.mcp import smart_state
+
+    monkeypatch.setenv("LEMONCROW_SMART_STATE_LOCK_TIMEOUT", "0.2")
+
+    seen_flags: list[int] = []
+
+    def _always_busy(_fd: object, flags: int, *_args: object, **_kwargs: object) -> None:
+        seen_flags.append(flags)
+        raise BlockingIOError("locked")
+
+    monkeypatch.setattr(fcntl, "flock", _always_busy)
+
+    started = _time.monotonic()
+    handle = smart_state._acquire_smart_state_flock()
+    elapsed = _time.monotonic() - started
+
+    assert handle is None
+    assert elapsed < 3.0, f"acquisition should give up near the 0.2s timeout, took {elapsed:.1f}s"
+
+    # The load-bearing assertion. Elapsed time alone cannot tell a bounded
+    # acquisition from a blocking one here: BlockingIOError is an OSError, so a
+    # blocking `flock(LOCK_EX)` under this mock also returns None immediately
+    # via the broad handler, and a timing-only test passes either way. What
+    # actually distinguishes them is the flag: every attempt must be LOCK_NB.
+    assert seen_flags, "flock was never attempted"
+    assert all(f & fcntl.LOCK_NB for f in seen_flags), (
+        f"every acquisition attempt must be non-blocking, got flags {seen_flags}"
+    )
+    # ...and it must actually retry to the deadline rather than degrade into a
+    # single try, which would drop the cross-process synchronisation entirely.
+    assert len(seen_flags) > 1, f"expected polling until the deadline, saw {len(seen_flags)} attempt(s)"
+
+
 def test_render_bash_text_omits_spill_hint_when_absent() -> None:
     from lemoncrow.gateway.adapters.mcp_server import _render_bash_text
 


### PR DESCRIPTION
## The bug

Edits that write to disk and then never return. The file lands, the response does not, and the host eventually times out — while the call keeps running and finishes `ok` long after its caller gave up.

From a local event log: of **1284 logged edits, 17 exceeded 60s**, every one completing successfully well past the host timeout.

## Why it is a lock, not slowness

The distribution gives it away. Two edits **started five minutes apart completed one second apart** — 11:16:44 and 11:16:45, after 45.4 and 39.8 minutes respectively. That is waiters being released together, not work finishing.

`_acquire_smart_state_flock` took `fcntl.flock(LOCK_EX)` with **no timeout**, on a lock file under the LemonCrow root. That lock is therefore **machine-global**: held across every MCP process and daemon on the host (5+ running here). One stalled holder parks every tool call in every other process behind it, with no error and no deadline.

The sharpest part: the parked call **has already done its real work**. It is queued only to record an advisory counter.

## The fix

Poll `LOCK_NB` to a deadline (5s, tunable via `LEMONCROW_SMART_STATE_LOCK_TIMEOUT`) with exponential backoff, and give up rather than wait forever. Giving up degrades to exactly the same unsynchronised path non-POSIX platforms already take, so it is not a new failure mode. Worst case is a lost counter update — cheaper than an unbounded stall of every tool call on the machine.

## What was ruled out

Each by measurement, not by reading:

| Suspect | Verdict |
|---|---|
| Post-edit hooks | Bounded — a `jj` shim sleeping 25s under `total_timeout_s=2` returned at **2048ms** |
| `CodeContextEngine` construction | Lazy, **0.01s** |
| Background reindex | Runs off-thread |
| The 4.9h worst outlier | Spans a machine sleep window in `pmset -g log` — a wall-clock artifact, not a hang |

## About the test

The obvious test here does not work, and the failure is worth naming because it is easy to ship by accident.

Mocking `flock` to raise `BlockingIOError` and asserting the call returns quickly **passes on the unfixed code too**: `BlockingIOError` is an `OSError`, so the original blocking `flock(LOCK_EX)` is caught by the existing broad handler and also returns `None` immediately. A timing-only assertion proves nothing.

So the test asserts the actual contract — **every acquisition attempt carries `LOCK_NB`** — plus that it genuinely polls to the deadline rather than degrading into a single try (which would silently drop cross-process synchronisation).

Confirmed decisive by running it against unpatched `main`:

```
E  AssertionError: every acquisition attempt must be non-blocking, got flags [2]
```

(`2` is `LOCK_EX`; `LOCK_NB` is `4`.)

## Verification

| Check | Result |
|---|---|
| New test, unpatched `main` | **fails** (flags `[2]`) |
| New test, with fix | **passes** |
| `tests/gateway/test_mcp_tool_handlers.py` | 12 failed / **147 passed** vs 12 failed / 146 on `main` — *identical* failure sets, +1 passing |
| `mypy --strict` on `smart_state.py` | **Success: no issues found** |
| `ruff check` on changed lines | clean |

The 12 pre-existing failures are unrelated to this change and present identically on `main` (verified by diffing the failure sets, not by assumption). This branch is diff-clean otherwise: the test change is **purely additive**, 44 insertions and 0 deletions.

> Two lint findings in `tests/gateway/test_mcp_tool_handlers.py` (an `I001` at line 886 and `ruff format` drift) are **pre-existing on pristine `main`** — confirmed against an untouched checkout — so I left them alone rather than mixing unrelated reformatting into this PR.

> `make pre-commit` was not run in full: this checkout has no `src/lemoncrow/pro` source (public mirror), so the project build and part of the suite cannot run locally. The scoped equivalents above were run instead, each against a same-command baseline on `main`.
