### PR TITLE
fix(bash): make an unknown shell session say which id would have worked

### DIFF
--- a/src/lemoncrow/gateway/adapters/mcp/bash.py
+++ b/src/lemoncrow/gateway/adapters/mcp/bash.py
@@ -29,7 +29,11 @@ from lemoncrow.gateway.adapters.mcp.deferral import (
 from lemoncrow.gateway.adapters.mcp.framework import TOOLS, mcp_tool
 from lemoncrow.gateway.adapters.mcp.fs_access import _claude_additional_dirs
 from lemoncrow.gateway.adapters.mcp.ledger import _check_redundant_file_dump, _request_bridge_id
-from lemoncrow.gateway.adapters.mcp.session_state import _forget_mcp_managed_bash, _record_mcp_managed_bash
+from lemoncrow.gateway.adapters.mcp.session_state import (
+    _forget_mcp_managed_bash,
+    _record_mcp_managed_bash,
+    live_managed_bash_ids,
+)
 from lemoncrow.gateway.adapters.mcp.smart_state import (
     _STATE_LOCK,
     _acquire_smart_state_flock,
@@ -159,6 +163,26 @@ def _record_bash_command_stats(command: str, *, shipped_chars: int, omitted_char
             _write_smart_state(state)
         finally:
             _release_smart_state_flock(_flock)
+
+
+# A host that caps MCP tool calls backgrounds the call when it runs long and
+# hands back a *task* id of its own -- Claude Code says "moved to the background
+# as task k31b54d8q ... use TaskStop with task_id". That id addresses the host's
+# task, never a managed shell, so feeding it back as bash(id=...) can only fail;
+# the shell handle is the shorter id inside the eventual completion payload.
+# Host task ids seen so far are 9 lowercase alphanumerics, managed shell ids 6,
+# so the shape is worth calling out -- as a hint only, never as a rejection.
+_HOST_TASK_ID_RE = re.compile(r"^[0-9a-z]{9}$")
+
+
+def _unknown_session_hint(session_id: str) -> str:
+    """Trailing clause naming what the caller could have polled instead."""
+    parts: list[str] = []
+    if _HOST_TASK_ID_RE.match(session_id):
+        parts.append("looks like a host background-task id (TaskStop/task output take it), not a shell id")
+    live = [sid for sid in live_managed_bash_ids() if sid != session_id]
+    parts.append("live sessions: " + ", ".join(live[:5]) if live else "no live sessions in this MCP process")
+    return " -- " + "; ".join(parts)
 
 
 def _default_bash_soft_timeout() -> int:
@@ -436,7 +460,7 @@ def _run_bash_tool(
             return {
                 "status": "error",
                 "session_id": session_id,
-                "stderr": f"unknown shell session: {session_id}",
+                "stderr": f"unknown shell session: {session_id}{_unknown_session_hint(session_id or '')}",
                 "exit_code": -1,
             }
 

--- a/src/lemoncrow/gateway/adapters/mcp/session_state.py
+++ b/src/lemoncrow/gateway/adapters/mcp/session_state.py
@@ -163,3 +163,26 @@ def _record_mcp_managed_bash(started: dict[str, Any]) -> None:
 def _forget_mcp_managed_bash(session_id: str) -> None:
     if session_id:
         _mutate_mcp_managed_bash(remove_id=session_id)
+
+
+def live_managed_bash_ids() -> list[str]:
+    """Session ids this MCP process currently owns, most recently started first.
+
+    Reads the same registration file ``_record_mcp_managed_bash`` writes, so a
+    poll against an id that does not exist can name the handles that would have
+    worked instead of dead-ending on "unknown shell session".
+    """
+    try:
+        data = json.loads(_mcp_session_file().read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return []
+    if not isinstance(data, dict):
+        return []
+    rows = [row for row in data.get("managed_bash", []) if isinstance(row, dict)]
+    rows.sort(key=lambda row: float(row.get("started_at") or 0.0), reverse=True)
+    seen: list[str] = []
+    for row in rows:
+        session_id = str(row.get("session_id") or "")
+        if session_id and session_id not in seen:
+            seen.append(session_id)
+    return seen

--- a/tests/gateway/test_mcp_tool_handlers.py
+++ b/tests/gateway/test_mcp_tool_handlers.py
@@ -2757,6 +2757,31 @@ def test_render_bash_text_includes_spill_hint_in_truncation_notice() -> None:
     assert "[output truncated: 50 lines omitted]" not in text
 
 
+def test_unknown_session_error_names_the_live_handles(monkeypatch: pytest.MonkeyPatch) -> None:
+    from lemoncrow.gateway.adapters.mcp import bash as bash_mod
+
+    monkeypatch.setattr(bash_mod, "live_managed_bash_ids", lambda: ["v334oo", "8muo9e"])
+
+    text = bash_mod.tool_bash({"id": "zzzzzz", "action": "status"})
+
+    assert "unknown shell session: zzzzzz" in text
+    assert "live sessions: v334oo, 8muo9e" in text
+
+
+def test_unknown_session_error_flags_a_host_task_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A host that caps MCP calls hands back its own task id; feeding that back
+    # as a shell handle can only fail, so the error has to say which id-space
+    # it landed in rather than repeating "unknown".
+    from lemoncrow.gateway.adapters.mcp import bash as bash_mod
+
+    monkeypatch.setattr(bash_mod, "live_managed_bash_ids", lambda: [])
+
+    text = bash_mod.tool_bash({"id": "k31b54d8q", "action": "status"})
+
+    assert "host background-task id" in text
+    assert "no live sessions in this MCP process" in text
+
+
 def test_render_bash_text_omits_spill_hint_when_absent() -> None:
     from lemoncrow.gateway.adapters.mcp_server import _render_bash_text
 


### PR DESCRIPTION
## The bug

A host that caps MCP tool-call duration backgrounds the call when it outruns that cap and hands back a **task id of its own**. Claude Code prints:

```
MCP tool "lc/bash" is still running after 120s. It was moved to the background
as task k6bagtwv5 ... To stop it, use TaskStop with task_id "k6bagtwv5".
```

That id addresses the **host's task**, never a managed shell. Feeding it back as `bash(id=...)` can only fail — the real shell handle is the shorter id inside the completion payload that arrives later. Two id-spaces, and the error named neither:

```
unknown shell session: k6bagtwv5
```

True, unhelpful, and it leaves the caller with no next move. The reported symptom was hitting it three times in one session.

> Both transcript excerpts above are real, captured **in the session that prepared this PR** — a long test run got backgrounded, and the reflex to pass that id to `bash(id=...)` produced exactly the bare error this changes. The right move was `TaskOutput`, which the message now says.

## The fix

The registration file already tracks every session this MCP process owns (`managed_bash` rows written by `_record_mcp_managed_bash`), so the answer was on disk the whole time. Read it, name the live handles, and call out the host-task-id shape when the unknown id has it:

```
unknown shell session: k31b54d8q -- looks like a host background-task id
(TaskStop/task output take it), not a shell id; live sessions: v334oo
```

**Hint only.** The shape check never rejects: an unrecognised id still fails exactly as it did, with the same error path and the same result. The only change is that the message now says which id-space the caller landed in and which handles would have worked.

`bg=true` was never affected — it returns the shell id in a response that completes before any host cap can fire.

## Scope

- `session_state.py` — adds `live_managed_bash_ids()`, reading the rows already written there.
- `bash.py` — builds the hint; `_session_not_found()` appends it.

The 9-lowercase-alphanumeric host-task shape is a heuristic used **only** to pick the wording. If a future host uses a different shape the hint simply does not fire, and the error degrades to what it says today.

## Verification

| Check | Result |
|---|---|
| 2 new tests, unpatched `main` | **fail** |
| 2 new tests, with fix | **pass** |
| `tests/gateway/test_mcp_tool_handlers.py` | 12 failed / **148 passed** vs 12 failed / 146 on `main` — *identical* failure sets, +2 passing |
| `mypy --strict` on both changed modules | **10 errors before, 10 after** — none added |
| `ruff check` on changed files | **All checks passed** |

The 12 pre-existing failures are unrelated and present identically on `main` — verified by diffing the failure sets rather than assuming. The test change is **purely additive**: 25 insertions, 0 deletions.

> `make pre-commit` was not run in full: this checkout has no `src/lemoncrow/pro` source (public mirror), so the project build and part of the suite cannot run locally. The scoped equivalents above were run instead, each against a same-command baseline on `main`.
