### PR TITLE
fix(paths): admit namespaced agent ids as path segments

### DIFF
--- a/src/lemoncrow/core/foundation/paths.py
+++ b/src/lemoncrow/core/foundation/paths.py
@@ -18,7 +18,10 @@ class WorkspaceNotRegisteredError(RuntimeError):
     workspace. Non-git directories are never silently auto-registered."""
 
 
-_SAFE_SEGMENT = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}")
+# The colon is intentional: agent identifiers are namespaced (``lemoncrow:code``)
+# and have always been used as directory segments. A colon cannot escape a
+# directory, so admitting it preserves the traversal protection below.
+_SAFE_SEGMENT = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,127}")
 
 
 def safe_segment(value: str, *, field: str = "value") -> str:

--- a/tests/gateway/test_service_api_path_traversal.py
+++ b/tests/gateway/test_service_api_path_traversal.py
@@ -53,6 +53,18 @@ def test_safe_segment_accepts_real_ids() -> None:
     assert safe_segment("run.json", field="session_id")
 
 
+def test_namespaced_agent_ids_survive_but_traversal_does_not() -> None:
+    """Regression: agent identifiers are namespaced (``lemoncrow:code``) and have
+    always been used as session-directory segments, so the colon must be
+    admitted -- but not at the cost of the traversal protection it was added
+    alongside (see ``_SAFE_SEGMENT`` in ``paths.py``)."""
+    assert safe_segment("lemoncrow:code", field="host") == "lemoncrow:code"
+
+    for bad in ("..", ".", "a/b", "../../etc/passwd", "", "a b", "a\\b"):
+        with pytest.raises(ValueError):
+            safe_segment(bad, field="host")
+
+
 @pytest.mark.parametrize("bad", TRAVERSAL_IDS)
 def test_session_dir_refuses_to_build_an_escaping_path(tmp_path: Path, bad: str) -> None:
     with pytest.raises(ValueError):


### PR DESCRIPTION
`9365c48d` added `safe_segment()` and wired it into `session_dir()`. The pattern is

```python
_SAFE_SEGMENT = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}")
```

which has no colon — and `session_dir()` runs the host through it:

```python
host = safe_segment(host, field="host")
```

Agent identifiers in this codebase are colon-namespaced (`lemoncrow:code`), and `host` is a literal directory segment: `sessions/YYYY/MM/DD/<host>/<session_id>/`. So every call raises

```
ValueError: invalid host: 'lemoncrow:code'
```

## Impact

This takes the MCP server down completely — every tool call fails, and it survives both an MCP reconnect and a full host-agent restart, because the rejected value is configuration rather than connection state.

It is reachable from a stock install: `scripts/install_claude.sh:568` writes `"agent": "lemoncrow:code"` into `~/.claude/settings.json`, and `plugin_runtime.py`'s `session_start_bootstrap()` re-asserts it every session — so clearing the setting by hand does not hold.

Reproduced on pristine `upstream/main` (`66f3fab0`), no fork code involved:

```
$ uv run python -c "from lemoncrow.core.foundation.paths import safe_segment; safe_segment('lemoncrow:code', field='host')"
ValueError: invalid host: 'lemoncrow:code'
```

## Cause

The commit message for `9365c48d` describes the goal precisely: *"Session/host/skill ids arriving from HTTP routes reached the store as raw path segments, so a crafted id could escape the store root."* That is a real hole and the fix is right. But the validator was placed in the shared `session_dir()` helper rather than at the HTTP boundary, so it also applies to long-standing internal callers that pass namespaced identifiers — values that never came from a route and were always used as directory names.

## Fix

Admit `:` in the character class:

```python
_SAFE_SEGMENT = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,127}")
```

A colon cannot escape a directory, so the guard keeps doing the job it was added for. `/`, `.`, `..`, NUL, spaces and absolute prefixes all stay rejected — the existing `TRAVERSAL_IDS` set is unchanged and still passes.

The regression test asserts both halves together, next to the existing traversal cases, so a future tightening of the pattern cannot silently drop the colon again:

```
$ uv run pytest tests/gateway/test_service_api_path_traversal.py -q
21 passed
```

```
accepted: lemoncrow:code
rejected: '..'          rejected: '/etc/passwd'
rejected: '.'           rejected: '../../../../etc'
rejected: 'a/b'         rejected: 'a\x00b'
rejected: ''            rejected: 'a b'
```

## Note on scope

Widening the pattern is the minimal change that unbreaks v0.7.3. The more thorough fix is to validate at the HTTP boundary in `core/service/api.py` and let trusted internal callers pass through unvalidated — that matches the original commit's stated intent, but it is a larger change and I did not want to bundle it with a fix for a total outage. Happy to follow up with it if you would prefer that shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ckb7QXjUgcjvaMwY6TcyEH
